### PR TITLE
Refresh explore screen data

### DIFF
--- a/app/src/main/java/com/karrar/movieapp/ui/explore/ExploringFragment.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/explore/ExploringFragment.kt
@@ -63,6 +63,11 @@ class ExploringFragment : BaseFragment<FragmentExploringBinding>() {
             TransitionInflater.from(context).inflateTransition(android.R.transition.move)
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshData()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setTitle(false)

--- a/app/src/main/java/com/karrar/movieapp/ui/explore/ExploringViewModel.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/explore/ExploringViewModel.kt
@@ -8,7 +8,6 @@ import com.karrar.movieapp.domain.usecases.GetGenreListUseCase
 import com.karrar.movieapp.domain.usecases.GetMediaByGenreIDUseCase
 import com.karrar.movieapp.ui.adapters.MediaInteractionListener
 import com.karrar.movieapp.ui.base.BaseViewModel
-import com.karrar.movieapp.ui.explore.GenresInteractionListener
 import com.karrar.movieapp.ui.category.GenreUIStateMapper
 import com.karrar.movieapp.ui.category.MediaUIStateMapper
 import com.karrar.movieapp.ui.explore.exploreUIState.ErrorUIState
@@ -45,6 +44,10 @@ class ExploringViewModel @Inject constructor(
 
     init {
         setMediaType(Constants.MOVIE_CATEGORIES_ID)
+    }
+
+    fun refreshData() {
+        getData()
     }
 
     override fun getData() {


### PR DESCRIPTION
# Pull Request Template
---

## Changes Made
List the changes introduced in this pull request:

- Added onResume() method in ExploringFragment to refresh data when fragment becomes visible
- Implemented refreshData() method in ExploringViewModel to trigger data reload

---

## Screenshots (if applicable)
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/060a5117-03da-4d6d-be55-f7bdff5b568e" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---